### PR TITLE
Fix UseDefaultBib with relative path

### DIFF
--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -101,6 +101,9 @@ export class Manager {
         }
         if (configuration.get('UseDefaultBib') && (configuration.get('DefaultBib') !== "")) {
             let bibFile = path.join(configuration.get('DefaultBib'));
+            if (!path.isAbsolute(bibFile)) { 
+                bibFile = path.join(vscode.workspace.rootPath, configuration.get('DefaultBib'));
+            }
             this.extension.log(`Looking for .bib file: ${bibFile}`);
             this.addBibToWatcher(bibFile);
             foundFiles.push(bibFile)


### PR DESCRIPTION
Fixes #10 

There is no check if the path is absolute or relative. I added a check for the DefaultBib case but I didn't test it.