### PR TITLE
add pandoc-crossref auto-completion and syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pandocciter",
     "displayName": "Pandoc Citer",
     "description": "Autocomplete bibtex citations for markdown/pandoc",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "publisher": "notZaki",
     "license": "MIT",
     "engines": {

--- a/src/providers/completer/crossref.ts
+++ b/src/providers/completer/crossref.ts
@@ -1,0 +1,53 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2021 Anran Yang
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import * as vscode from 'vscode';
+import { Extension } from '../../extension';
+
+export class Crossref {
+    extension: Extension;
+    regex: RegExp;
+
+    constructor(extension: Extension) {
+        this.extension = extension;
+        this.regex = /!\[(.+)\]\((.+)\)\{.*#(fig|tbl|eq|sec|lst):(\w+).*\}/g;
+    }
+
+    provide(args?: {
+        document: vscode.TextDocument;
+    }): vscode.CompletionItem[] {
+        const targets = [];
+        let match: RegExpExecArray | null;
+        while ((match = this.regex.exec(args.document.getText())) !== null) {
+            const title = match[1];
+            const file = match[2];
+            const type = match[3];
+            const label = match[4];
+            targets.push({
+                label: `${type}:${label}`,
+                documentation: title,
+                kind: vscode.CompletionItemKind.Reference,
+            });
+        }
+        return targets;
+    }
+}

--- a/syntaxes/citations.json
+++ b/syntaxes/citations.json
@@ -21,6 +21,10 @@
             },
             "match": "(\\[)(-?@(.*?))(?=$|[\\s\\r\\n\\]{},~#%\\\\'\"=\\(\\)])",
             "name": "meta.paragraph.markdown"
+        },
+        "pandoc-crossref":{
+            "match": "\\@(fig|tbl|sec|eq|lst):\\w+",
+            "name": "string.other.link.description.markdown.citation"
         }
     },
     "scopeName": "pandoc-citation"


### PR DESCRIPTION
Add auto-completion and a simple syntax highlighting for pandoc-crossref. Please refer to https://github.com/lierdakil/pandoc-crossref, especially https://github.com/lierdakil/pandoc-crossref/blob/master/docs/index.md.

This pandoc addon adds a general syntax to label images, tables, equations, etc., and crossref them in the main text.

Behavior of the modified version: When typing @, the extension will show both suggestions from pandoc-citer and pandoc-crossref, users can type prefixes like @fig: to further filter. This patch is a possible fix for #20.

The change will not break the original functionality if users do not use pandoc-crossref.
