### PR TITLE
Implement hover and go to definition providers for citations

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 
 import {Manager} from './components/manager';
 import {Completer} from './providers/completion';
+import {HoverProvider} from './providers/hover'
 
 export function activate(context: vscode.ExtensionContext) {
     const extension = new Extension();
@@ -40,16 +41,28 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(
         {scheme: 'file', language: 'pweave_md'}, 
         extension.completer, '@'));
+
+    context.subscriptions.push(vscode.languages.registerHoverProvider(
+        {scheme: 'file', language: 'markdown'}, 
+        extension.hover));
+    context.subscriptions.push(vscode.languages.registerHoverProvider(
+        {scheme: 'file', language: 'rmd'}, 
+        extension.hover));
+    context.subscriptions.push(vscode.languages.registerHoverProvider(
+        {scheme: 'file', language: 'pweave_md'}, 
+        extension.hover));
 }
 
 export class Extension {
     manager: Manager;
     completer: Completer;
+    hover: HoverProvider;
     logPanel: vscode.OutputChannel;
 
     constructor() {
         this.manager = new Manager(this);
         this.completer = new Completer(this);
+        this.hover = new HoverProvider(this);
         this.logPanel = vscode.window.createOutputChannel('PandocCiter');
         this.log(`PandocCiter is now activated`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,8 @@ import * as vscode from 'vscode';
 
 import {Manager} from './components/manager';
 import {Completer} from './providers/completion';
-import {HoverProvider} from './providers/hover'
+import {HoverProvider} from './providers/hover';
+import {DefinitionProvider} from './providers/definition';
 
 export function activate(context: vscode.ExtensionContext) {
     const extension = new Extension();
@@ -31,38 +32,31 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }));
 
+    const selector = ['markdown','rmd','pweave_md'].map((language)=>{
+        return {scheme: 'file', language: language};
+    });
+
     extension.manager.findBib();
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(
-        {scheme: 'file', language: 'markdown'}, 
-        extension.completer, '@'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(
-        {scheme: 'file', language: 'rmd'}, 
-        extension.completer, '@'));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(
-        {scheme: 'file', language: 'pweave_md'}, 
-        extension.completer, '@'));
-
+        selector, extension.completer, '@'));
     context.subscriptions.push(vscode.languages.registerHoverProvider(
-        {scheme: 'file', language: 'markdown'}, 
-        extension.hover));
-    context.subscriptions.push(vscode.languages.registerHoverProvider(
-        {scheme: 'file', language: 'rmd'}, 
-        extension.hover));
-    context.subscriptions.push(vscode.languages.registerHoverProvider(
-        {scheme: 'file', language: 'pweave_md'}, 
-        extension.hover));
+        selector, extension.hover));
+    context.subscriptions.push(vscode.languages.registerDefinitionProvider(
+        selector, extension.definition));
 }
 
 export class Extension {
     manager: Manager;
     completer: Completer;
     hover: HoverProvider;
+    definition: DefinitionProvider;
     logPanel: vscode.OutputChannel;
 
     constructor() {
         this.manager = new Manager(this);
         this.completer = new Completer(this);
         this.hover = new HoverProvider(this);
+        this.definition = new DefinitionProvider(this);
         this.logPanel = vscode.window.createOutputChannel('PandocCiter');
         this.log(`PandocCiter is now activated`);
     }

--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -135,6 +135,12 @@ export class Citation {
         this.extension.log(`Parsed ${this.bibEntries[file].length} bib entries from ${file}.`);
     }
 
+    getEntry(key: string): Suggestion | undefined {
+        const suggestions = this.updateAll()
+        const entry = suggestions.find((elm) => elm.key === key)
+        return entry
+    }
+
     private deParenthesis(str: string) {
         return str.replace(/{+([^\\{}]+)}+/g, '$1');
     }

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Extension } from '../extension';
+import * as fs from 'fs';
 
 export class DefinitionProvider implements vscode.DefinitionProvider {
 	extension: Extension;
@@ -10,7 +11,7 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
 
 	provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.Location | undefined {
 		// look for an @ at the start of the current word (start) and the end of the current word or line (end)
-		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]/);
+		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]\w*$/);
 		const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/$|\s/);
 		if (startResult === null || endResult === null ||
 			startResult.index === undefined || endResult.index === undefined ||
@@ -18,7 +19,7 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
 			return undefined;
 		}
 
-		const invoker = startResult[0];
+		const invoker = startResult[0][0];
 		if (invoker !== '@') { return; }
 
 		const line = document.getText(new vscode.Range(

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { Extension } from '../extension';
-import * as fs from 'fs';
 
 export class DefinitionProvider implements vscode.DefinitionProvider {
 	extension: Extension;
@@ -10,25 +9,14 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
 	}
 
 	provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.Location | undefined {
-		// look for an @ at the start of the current word (start) and the end of the current word or line (end)
-		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]\w*$/);
-		const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/$|\s/);
-		if (startResult === null || endResult === null ||
-			startResult.index === undefined || endResult.index === undefined ||
-			startResult.index < 0 || endResult.index < 0) {
-			return undefined;
-		}
-
-		const invoker = startResult[0][0];
-		if (invoker !== '@') { return; }
-
-		const line = document.getText(new vscode.Range(
-			new vscode.Position(position.line, startResult.index + 1),
-			new vscode.Position(position.line, position.character + endResult.index)
-		)).trim()
-		const cite = this.extension.completer.citation.getEntry(line);
-		if (cite) {
-			return new vscode.Location( vscode.Uri.file(cite.file), cite.position )
+		// a cite key is an @ symbol followed by word characters (letters or numbers)
+		const keyRange = document.getWordRangeAtPosition(position, /(?<=@)\w+/);
+		if (keyRange){
+			const citeKey = document.getText(keyRange);
+			const cite = this.extension.completer.citation.getEntry(citeKey);
+			if (cite) {
+				return new vscode.Location(vscode.Uri.file(cite.file), cite.position);
+			}
 		}
 	}
 }

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { Extension } from '../extension';
+
+export class DefinitionProvider implements vscode.DefinitionProvider {
+	extension: Extension;
+
+	constructor(extension: Extension) {
+		this.extension = extension
+	}
+
+	provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.Location | undefined {
+		// look for an @ at the start of the current word (start) and the end of the current word or line (end)
+		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]/);
+		const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/$|\s/);
+		if (startResult === null || endResult === null ||
+			startResult.index === undefined || endResult.index === undefined ||
+			startResult.index < 0 || endResult.index < 0) {
+			return undefined;
+		}
+
+		const invoker = startResult[0];
+		if (invoker !== '@') { return; }
+
+		const line = document.getText(new vscode.Range(
+			new vscode.Position(position.line, startResult.index + 1),
+			new vscode.Position(position.line, position.character + endResult.index)
+		)).trim()
+		const cite = this.extension.completer.citation.getEntry(line);
+		if (cite) {
+			return new vscode.Location( vscode.Uri.file(cite.file), cite.position )
+		}
+	}
+}

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -30,7 +30,7 @@ export class HoverProvider implements vscode.HoverProvider {
 
 		if (cite) {
 			let md = cite.documentation || cite.detail;
-			md = md.replace(/\n/g, '\n\n'); // need double newlines for the formatting to work in markdown?
+			md = md.replace(/\n/g, '  \n'); // need double space then a newline to actually get a newline in markdown
 			if (md) {
 				return new vscode.Hover(md)
 			}

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode'
+import { Extension } from '../extension';
+
+export class HoverProvider implements vscode.HoverProvider {
+	extension: Extension;
+
+	constructor(extension: Extension) {
+		this.extension = extension;
+	}
+
+	public async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover | undefined> {
+
+		// look for an @ at the start of the current word (start) and the end of the current word or line (end)
+		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]/);
+		const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/$|\s/);
+		if (startResult === null || endResult === null ||
+			startResult.index === undefined || endResult.index === undefined ||
+			startResult.index < 0 || endResult.index < 0) {
+			return undefined;
+		}
+
+		const invoker = startResult[0];
+		if (invoker !== '@') { return; }
+
+		const line = document.getText(new vscode.Range(
+			new vscode.Position(position.line, startResult.index + 1),
+			new vscode.Position(position.line, position.character + endResult.index)
+		)).trim()
+		const cite = this.extension.completer.citation.getEntry(line);
+
+		if (cite) {
+			let md = cite.documentation || cite.detail;
+			md = md.replace(/\n/g, '\n\n'); // need double newlines for the formatting to work in markdown?
+			if (md) {
+				return new vscode.Hover(md)
+			}
+		}
+
+		return undefined;
+	}
+}

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -9,33 +9,18 @@ export class HoverProvider implements vscode.HoverProvider {
 	}
 
 	public async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover | undefined> {
-
-		// look for an @ at the start of the current word (start) and the end of the current word or line (end)
-		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]\w*$/);
-		const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/$|\s/);
-		if (startResult === null || endResult === null ||
-			startResult.index === undefined || endResult.index === undefined ||
-			startResult.index < 0 || endResult.index < 0) {
-			return undefined;
-		}
-
-		const invoker = startResult[0][0];
-		if (invoker !== '@') { return; }
-
-		const line = document.getText(new vscode.Range(
-			new vscode.Position(position.line, startResult.index + 1),
-			new vscode.Position(position.line, position.character + endResult.index)
-		)).trim()
-		const cite = this.extension.completer.citation.getEntry(line);
-
-		if (cite) {
-			let md = cite.documentation || cite.detail;
-			md = md.replace(/\n/g, '  \n'); // need double space then a newline to actually get a newline in markdown
-			if (md) {
-				return new vscode.Hover(md)
+		// a cite key is an @ symbol followed by word characters (letters or numbers)
+		const keyRange = document.getWordRangeAtPosition(position, /(?<=@)\w+/);
+		if (keyRange){
+			const citeKey = document.getText(keyRange);
+			const cite = this.extension.completer.citation.getEntry(citeKey);
+			if (cite) {
+				let hoverMarkdownText = cite.documentation || cite.detail;
+				hoverMarkdownText = hoverMarkdownText.replace(/\n/g, '  \n'); // need double space then a newline to actually get a newline in markdown
+				if (hoverMarkdownText) {
+					return new vscode.Hover(hoverMarkdownText)
+				}
 			}
 		}
-
-		return undefined;
 	}
 }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -11,7 +11,7 @@ export class HoverProvider implements vscode.HoverProvider {
 	public async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover | undefined> {
 
 		// look for an @ at the start of the current word (start) and the end of the current word or line (end)
-		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]/);
+		const startResult = document.getText(new vscode.Range(new vscode.Position(position.line, 0), position)).match(/[\b@]\w*$/);
 		const endResult = document.getText(new vscode.Range(position, new vscode.Position(position.line, 65535))).match(/$|\s/);
 		if (startResult === null || endResult === null ||
 			startResult.index === undefined || endResult.index === undefined ||
@@ -19,7 +19,7 @@ export class HoverProvider implements vscode.HoverProvider {
 			return undefined;
 		}
 
-		const invoker = startResult[0];
+		const invoker = startResult[0][0];
 		if (invoker !== '@') { return; }
 
 		const line = document.getText(new vscode.Range(


### PR DESCRIPTION
Addresses #28

Hover provider:
![image](https://user-images.githubusercontent.com/26859884/145679331-0f8dba7b-5342-4e1b-8df7-59743aced031.png)

Go to definition provider (Ctrl + hover):
![image](https://user-images.githubusercontent.com/26859884/145682035-f0ea74c2-242d-4208-aa64-a45e031e9772.png)


This is mostly a simplified version from LaTeX workshop's [hover provider](https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/providers/hover.ts) and [go to definition provider](https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/providers/definition.ts).

* For the hover provider, I had to replace newlines in the text with two spaces then a newline, otherwise everything rendered on one line. LaTeX Workshop does this when parsing the documentation initially [here](https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/providers/completer/citation.ts#L253) - I'm not sure if it's worth doing the same
* I'm not convinced my regexp to select the citation key is robust - do you have any advice? And since it's reused twice, would it be worth spinning out to a separate function/file?
