### PR TITLE
Add ( to starting characters

### DIFF
--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -63,7 +63,7 @@ export class Completer implements vscode.CompletionItemProvider {
     }
 
     completion(line: string) : vscode.CompletionItem[] {
-        let reg = /(?:^|[ ;\[-])\@([^\]\s]*)/;
+        let reg = /(?:^|[ ;\(\[-])\@([^\]\s]*)/;
         let provider = this.citation;
             
         const result = line.match(reg);


### PR DESCRIPTION
Added a round open bracket to the allowed starting characters for a citation. This is to make it possible to cite in round brackets instead of having to use square brackets.