### PR TITLE
Fix: match unicode letter citation key for hover and go to definition

### DIFF
--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -10,7 +10,7 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
 
 	provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.Location | undefined {
 		// a cite key is an @ symbol followed by word characters (letters or numbers)
-		const keyRange = document.getWordRangeAtPosition(position, /(?<=@)\w+/);
+		const keyRange = document.getWordRangeAtPosition(position, /(?<=@)[\w\p{L}\p{M}]+/u);
 		if (keyRange){
 			const citeKey = document.getText(keyRange);
 			const cite = this.extension.completer.citation.getEntry(citeKey);

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -10,7 +10,7 @@ export class HoverProvider implements vscode.HoverProvider {
 
 	public async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover | undefined> {
 		// a cite key is an @ symbol followed by word characters (letters or numbers)
-		const keyRange = document.getWordRangeAtPosition(position, /(?<=@)\w+/);
+		const keyRange = document.getWordRangeAtPosition(position, /(?<=@)[\w\p{L}\p{M}]+/u);
 		if (keyRange){
 			const citeKey = document.getText(keyRange);
 			const cite = this.extension.completer.citation.getEntry(citeKey);


### PR DESCRIPTION
# Problem

Currently, we use the regexp `/(?<=@)\w+/` to match citation keys for hover and go-to-definition. However, this expression can only match ASCII characters, and you can use non-ASCII characters (like CJK characters, French accent characters, and so on) in BibTeX citation keys if compiled with an engine that supports unicode like XeLaTeX.

# Solution

This PR changes the regexp `/(?<=@)\w+/` to `/(?<=@)[\w\p{L}\p{M}]+/u` for solve the problem above, using the [unicode property escapes](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Unicode_property_escapes).

## Explanation

`\p{L}` match any kind of letter from any language.

`\p{M}` matches character intended to be combined with another character (e.g. accents, umlauts, enclosing boxes, etc.).

`/u` treat a pattern as a sequence of Unicode code points.

Reference: 

https://www.regular-expressions.info/unicode.html

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags

# Preview

<img height="150px" src="https://user-images.githubusercontent.com/36927158/230726329-d8a3eee6-5617-4989-9f34-888681d5dbdf.png"></img>

<img height="150px" src="https://user-images.githubusercontent.com/36927158/230726334-69da9c55-35bf-459c-a441-55df6e843d2e.png"></img>