### PR TITLE
filter autocomplete suggestions by key in addition to fields

### DIFF
--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -54,7 +54,7 @@ export class Citation {
   }): vscode.CompletionItem[] {
     // Compile the suggestion array to vscode completion array
     return this.updateAll().map((item) => {
-      item.filterText = Object.values(item.fields).join(" ");
+      item.filterText = [item.key, ...Object.values(item.fields)].join(" ");
       item.insertText = item.key;
       if (args) {
         item.range = args.document.getWordRangeAtPosition(


### PR DESCRIPTION
Previously, the autocomplete suggestion box did not filter by keys. This led to some strange behaviour where typing the exact name of a key would not show that entry in the suggestion box, or where an entry with a key that exactly matches what the user has typed would appear much further down the list than others. This PR solves that issue by prepending the item key to the item fields for filtering.