### PR TITLE
Search bib entries by key and field substring

### DIFF
--- a/src/providers/completer/citation.ts
+++ b/src/providers/completer/citation.ts
@@ -54,13 +54,21 @@ export class Citation {
   }): vscode.CompletionItem[] {
     // Compile the suggestion array to vscode completion array
     return this.updateAll().map((item) => {
-      item.filterText = Object.values(item.fields).join(" ");
+      // Include the cite key itself in the filter text so users can search
+      // by any fragment of the key, not only by the fields.
+      item.filterText =
+        item.key + " " + Object.values(item.fields).join(" ");
       item.insertText = item.key;
       if (args) {
-        item.range = args.document.getWordRangeAtPosition(
+        // Right after the trigger `@` there is no word yet, so
+        // getWordRangeAtPosition returns undefined. Fall back to an empty
+        // range at the cursor so VS Code knows the replacement anchor.
+        const wordRange = args.document.getWordRangeAtPosition(
           args.position,
           /[-a-zA-Z0-9_:.]+/
         );
+        item.range =
+          wordRange ?? new vscode.Range(args.position, args.position);
       }
       return item;
     });

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -46,7 +46,7 @@ export class Completer implements vscode.CompletionItemProvider {
     position: vscode.Position,
     _token: vscode.CancellationToken,
     context: vscode.CompletionContext
-  ): vscode.CompletionItem[] | undefined {
+  ): vscode.CompletionList | undefined {
     // This was used to terminate unecessary autompletion early, but might be causing suggestions to not appear for some users
     // const invoker = document.lineAt(position.line).text[position.character-1];
     // if (invoker !== '@') {return;}
@@ -56,7 +56,7 @@ export class Completer implements vscode.CompletionItemProvider {
       .trim()
       .split(" ");
     const trigger = line[line.length - 1];
-    const suggestions = this.completion(trigger).concat(
+    const suggestions = this.completion(trigger, document, position).concat(
       this.completionCrossref(trigger, document)
     );
     this.extension.log(`Showing ${suggestions.length} suggestions`);
@@ -66,20 +66,57 @@ export class Completer implements vscode.CompletionItemProvider {
         setTimeout(() => this.citation.browser(), 10);
         return;
       }
-      // current crossref do not support browser mode
-      return suggestions;
+      // Mark the list as incomplete so VS Code re-invokes this provider on
+      // every keystroke, which lets us re-run the substring filter below
+      // against the full typed query instead of relying on the built-in
+      // client-side fuzzy filter.
+      return new vscode.CompletionList(suggestions, true);
     }
     return;
   }
 
-  completion(line: string): vscode.CompletionItem[] {
+  completion(
+    line: string,
+    document?: vscode.TextDocument,
+    position?: vscode.Position
+  ): vscode.CompletionItem[] {
     let reg = /(?:^|[ ;\[-])\@([^\]\s]*)/;
     let provider = this.citation;
 
     const result = line.match(reg);
     let suggestions: vscode.CompletionItem[] = [];
     if (result) {
-      suggestions = provider.provide();
+      const query = result[1].toLowerCase();
+      const args =
+        document && position
+          ? {
+              document,
+              position,
+              token: undefined as unknown as vscode.CancellationToken,
+              context: undefined as unknown as vscode.CompletionContext,
+            }
+          : undefined;
+      const allItems = provider.provide(args);
+      if (query.length === 0) {
+        suggestions = allItems;
+      } else {
+        // Substring match across the key plus every indexed field, so users
+        // can find an entry by any word in the title/author/journal, not only
+        // by the prefix of the cite key.
+        suggestions = allItems
+          .filter((item) => {
+            const searchText = (
+              (item.filterText as string) || String(item.label)
+            ).toLowerCase();
+            return searchText.includes(query);
+          })
+          .map((item) => {
+            // Prepend the query so VS Code's own fuzzy filter always passes
+            // the items we already matched server-side.
+            item.filterText = query + " " + (item.filterText || "");
+            return item;
+          });
+      }
     }
 
     return suggestions;


### PR DESCRIPTION
## Summary

Improves `@` citation completion so that typing any substring of the **cite key**, **title**, or **author** reliably finds matching entries. Previously the client-side fuzzy filter would frequently drop obviously-matching items.

Example: with an entry whose key is `smith2024deeplearning` and title "Deep Learning for Everyone", typing `@deep`, `@learning`, or `@smith` now consistently surfaces that entry. Before this change, some of those queries would not.

Refs #33.

## What changed

- `citation.ts`
  - Include the cite key in `filterText` alongside the indexed fields.
  - Provide an empty-range fallback when `getWordRangeAtPosition` returns `undefined` right after the `@` trigger (no word character yet), so VS Code has a replacement anchor.

- `completion.ts`
  - Pass `document` / `position` through `completion()` to the citation provider.
  - Perform a case-insensitive substring filter server-side across key + every indexed field.
  - Rewrite `filterText` to start with the current query so VS Code's own client-side filter passes through the items we already matched.
  - Return a `CompletionList` with `isIncomplete = true`, so VS Code re-invokes the provider on every keystroke and the server-side filter runs against the full typed query.

## Test plan

- [ ] Typing a substring of the **cite key** (e.g. `@smith`) lists matching entries.
- [ ] Typing a word from the **title** (e.g. `@learning`) lists matching entries.
- [ ] Typing a word from an **author** name lists matching entries.
- [ ] Typing `@` alone still lists all entries.
- [ ] Browser-mode picker (`PandocCiter.ViewType = "browser"`) path is unchanged.
- [ ] Selecting a completion inserts the cite key and removes the typed prefix (no duplicate text).